### PR TITLE
Handle stop parameter compatibility for Hugging Face client

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ python -m tdl_translation.cli "Move the 2kg box from the storage rack to the loa
 
 The command prints the generated TDL program and a summary of the deployment stage. Use `--json` to inspect all intermediate artifacts or `--show-logs` to display the state machine transitions.
 
+To invoke a hosted Gemma model through Hugging Face for both requirement analysis and TDL formatting, supply your access token (either via `--hf-token` or the `HUGGINGFACE_API_TOKEN` environment variable) and enable the integration flag:
+
+```bash
+export HUGGINGFACE_API_TOKEN=hf_xxx
+python -m tdl_translation.cli "Move the 2kg box from the storage rack to the loading dock carefully." \
+  --use-hf-gemma --hf-model google/gemma-2-9b-it --hf-temperature 0.2
+```
+
+The Hugging Face configuration options allow you to tune sampling parameters such as `--hf-max-tokens` and `--hf-top-p` when experimenting with different Gemma checkpoints.
+
 Automated tests validate a successful happy path run as well as safety constraint handling:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ description = "Reference implementation of a TDL translation pipeline"
 authors = [{ name = "TDL Translation Maintainers" }]
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "huggingface-hub>=0.21",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tdl_translation/__init__.py
+++ b/tdl_translation/__init__.py
@@ -4,3 +4,10 @@ from .artifacts import *  # noqa: F401,F403 - convenient re-exports
 from .pipeline import TDLPipeline
 
 __all__ = ["TDLPipeline"]
+
+try:  # pragma: no cover - optional export
+    from .hf_gemma import GemmaTDLCompiler, HuggingFaceConfig, HuggingFaceGemmaService
+
+    __all__.extend(["GemmaTDLCompiler", "HuggingFaceConfig", "HuggingFaceGemmaService"])
+except Exception:  # pragma: no cover - huggingface optional at import time
+    pass

--- a/tdl_translation/hf_gemma.py
+++ b/tdl_translation/hf_gemma.py
@@ -1,0 +1,254 @@
+"""Integration helpers for calling Gemma models via the Hugging Face Inference API."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from .artifacts import MotionPlan, TaskSpec, TDLProgram
+from .components import GemmaLLMService, TDLCompiler
+from .errors import RequirementAnalysisError, TDLGenerationError
+
+try:  # pragma: no cover - optional dependency import guard
+    from huggingface_hub import InferenceClient
+except Exception:  # pragma: no cover - handled at runtime
+    InferenceClient = None  # type: ignore[assignment]
+
+
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+_CODE_BLOCK_RE = re.compile(r"```(?:tdl)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+
+
+def _default_token(token: Optional[str]) -> str:
+    resolved = token or os.getenv("HUGGINGFACE_API_TOKEN") or os.getenv("HF_API_TOKEN")
+    if not resolved:
+        raise ValueError(
+            "A Hugging Face access token must be supplied either via the constructor "
+            "or the HUGGINGFACE_API_TOKEN/HF_API_TOKEN environment variables."
+        )
+    return resolved
+
+
+def _extract_json_object(payload: str) -> Dict[str, Any]:
+    match = _JSON_BLOCK_RE.search(payload)
+    if not match:
+        raise RequirementAnalysisError("LLM response did not contain a JSON object")
+    try:
+        return json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise RequirementAnalysisError(f"Failed to parse JSON from LLM response: {exc}") from exc
+
+
+def _extract_tdl_block(payload: str) -> str:
+    match = _CODE_BLOCK_RE.search(payload)
+    if match:
+        candidate = match.group(1).strip()
+    else:
+        candidate = payload.strip()
+    if "TDL TASK" not in candidate:
+        raise TDLGenerationError("LLM response did not contain a TDL TASK block")
+    return candidate
+
+
+@dataclass
+class HuggingFaceConfig:
+    """Configuration for the Hugging Face Gemma integration."""
+
+    model: str = "google/gemma-2-9b-it"
+    token: Optional[str] = None
+    temperature: float = 0.1
+    max_tokens: int = 1024
+    top_p: float = 0.9
+    stop_sequences: Optional[Iterable[str]] = None
+
+
+class _ChatMixin:
+    """Helper mixin that wraps the Hugging Face chat completion API."""
+
+    def __init__(self, *, config: HuggingFaceConfig, client: Optional[Any] = None) -> None:
+        if client is not None:
+            self._client = client
+        else:
+            if InferenceClient is None:  # pragma: no cover - import guard
+                raise ImportError(
+                    "huggingface_hub is required to use HuggingFaceGemmaService. Install the extra dependency"
+                )
+            token = _default_token(config.token)
+            self._client = InferenceClient(model=config.model, token=token)
+        self._config = config
+
+    def _chat(self, system_prompt: str, user_prompt: str) -> str:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        base_kwargs = {
+            "messages": messages,
+            "temperature": self._config.temperature,
+            "max_tokens": self._config.max_tokens,
+            "top_p": self._config.top_p,
+        }
+        stop_values: Tuple[str, ...] = tuple(self._config.stop_sequences or ("</s>",))
+
+        response = None
+        last_type_error: Optional[TypeError] = None
+
+        for stop_kw in ("stop", "stop_sequences"):
+            kwargs = dict(base_kwargs)
+            if stop_values:
+                kwargs[stop_kw] = list(stop_values)
+            try:
+                response = self._client.chat_completion(  # type: ignore[operator]
+                    **kwargs
+                )
+                break
+            except TypeError as exc:
+                message = str(exc)
+                if "unexpected keyword" in message and stop_kw in message:
+                    last_type_error = exc
+                    continue
+                raise
+
+        if response is None:
+            raise last_type_error or TypeError(
+                "Failed to call Hugging Face chat completion API due to incompatible parameters"
+            )
+        try:
+            choice = response.choices[0]
+            content = choice.message["content"] if isinstance(choice.message, Mapping) else choice.message.content
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"Unexpected response format from Hugging Face API: {response}") from exc
+        if not isinstance(content, str):
+            raise RuntimeError(f"Unexpected message content from Hugging Face API: {content!r}")
+        return content
+
+
+class HuggingFaceGemmaService(GemmaLLMService, _ChatMixin):
+    """LLM-backed requirement analysis using Hugging Face hosted Gemma models."""
+
+    def __init__(
+        self,
+        *,
+        config: Optional[HuggingFaceConfig] = None,
+        client: Optional[Any] = None,
+    ) -> None:
+        self._config = config or HuggingFaceConfig()
+        _ChatMixin.__init__(self, config=self._config, client=client)
+
+    def analyze_requirement(
+        self,
+        command: str,
+        *,
+        knowledge_base: Optional[Dict[str, str]] = None,
+    ) -> TaskSpec:
+        if not command.strip():
+            raise RequirementAnalysisError("Empty command provided")
+
+        kb_display = json.dumps(knowledge_base or {}, indent=2, ensure_ascii=False)
+        system_prompt = (
+            "You are an expert industrial robotics planner. "
+            "Extract structured task specifications from operator requests. "
+            "Always respond with strict JSON matching the provided schema."
+        )
+        user_prompt = f"""
+Instruction:
+{command.strip()}
+
+KnowledgeBase:
+{kb_display}
+
+Respond with a JSON object containing the following keys:
+- goal (string, echo the operator instruction)
+- constraints (array of strings)
+- environment_context (object mapping string keys to string values)
+- success_criteria (array of strings)
+- required_payload_kg (number)
+- source_location (string or null)
+- target_location (string or null)
+- priority (integer from 1-5, 1 is highest urgency)
+Ensure the JSON is valid and does not include trailing commentary.
+"""
+        content = self._chat(system_prompt, user_prompt)
+        data = _extract_json_object(content)
+
+        try:
+            return TaskSpec(
+                goal=str(data.get("goal", command.strip())),
+                constraints=list(data.get("constraints", [])),
+                environment_context={k: str(v) for k, v in dict(data.get("environment_context", {})).items()},
+                success_criteria=list(data.get("success_criteria", [])),
+                required_payload_kg=float(data.get("required_payload_kg", 0.0)),
+                source_location=(data.get("source_location") or None),
+                target_location=(data.get("target_location") or None),
+                priority=int(data.get("priority", 5)),
+            )
+        except (TypeError, ValueError) as exc:
+            raise RequirementAnalysisError(f"LLM returned malformed TaskSpec fields: {exc}") from exc
+
+
+class GemmaTDLCompiler(TDLCompiler, _ChatMixin):
+    """TDL compiler that asks a Gemma model to format the motion plan."""
+
+    def __init__(
+        self,
+        *,
+        config: Optional[HuggingFaceConfig] = None,
+        client: Optional[Any] = None,
+    ) -> None:
+        self._config = config or HuggingFaceConfig()
+        _ChatMixin.__init__(self, config=self._config, client=client)
+
+    def generate_program(self, task: TaskSpec, motion_plan: MotionPlan) -> TDLProgram:
+        if not motion_plan.steps:
+            raise TDLGenerationError("Motion plan did not contain any steps")
+
+        steps_payload: List[Dict[str, Any]] = []
+        for step in motion_plan.steps:
+            steps_payload.append(
+                {
+                    "name": step.waypoint.name,
+                    "position": [round(float(coord), 4) for coord in step.waypoint.position],
+                    "joints": step.joint_targets,
+                    "gripper": step.gripper,
+                }
+            )
+
+        system_prompt = (
+            "You are a compiler that formats motion plans into valid Task Description Language (TDL). "
+            "Return only the TDL program."
+        )
+        user_prompt = f"""
+Create a TDL program for the following task specification and motion steps.
+TaskSpec:
+{json.dumps(asdict(task), indent=2, ensure_ascii=False)}
+
+MotionPlan Steps (ordered):
+{json.dumps(steps_payload, indent=2, ensure_ascii=False)}
+
+Requirements:
+- Emit a single TDL TASK block named 'auto_generated_task'.
+- Include a precondition of robot_ready and postcondition of task_complete.
+- For each step emit a move_to entry matching this schema:
+    - move_to name='waypoint_name' coords=(x.xxx, y.yyy, z.zzz) joints={{...}} gripper=state
+- Include success_criteria and constraints arrays from the task spec if they are not empty.
+Respond only with the TDL code. Do not add explanations.
+"""
+        content = self._chat(system_prompt, user_prompt)
+        tdl_text = _extract_tdl_block(content)
+
+        metadata = {
+            "generated_from": "GemmaTDLCompiler",
+            "duration_s": f"{motion_plan.duration_s:.2f}",
+            "model": self._config.model,
+        }
+        return TDLProgram(text=tdl_text, metadata=metadata)
+
+
+__all__ = [
+    "GemmaTDLCompiler",
+    "HuggingFaceConfig",
+    "HuggingFaceGemmaService",
+]

--- a/tests/test_hf_integration.py
+++ b/tests/test_hf_integration.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from tdl_translation.artifacts import MotionPlan, MotionStep, TaskSpec, Waypoint
+from tdl_translation.hf_gemma import GemmaTDLCompiler, HuggingFaceConfig, HuggingFaceGemmaService
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = {"content": content}
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeClient:
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+        self.calls = []
+
+    def chat_completion(self, *, messages, **_: object):  # type: ignore[override]
+        self.calls.append(messages)
+        if not self._responses:
+            raise AssertionError("No responses configured for fake client")
+        return _FakeResponse(self._responses.pop(0))
+
+
+class _StopFallbackClient:
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.calls = []
+
+    def chat_completion(self, **kwargs):  # type: ignore[override]
+        self.calls.append(kwargs)
+        if "stop" in kwargs:
+            raise TypeError("chat_completion() got an unexpected keyword argument 'stop'")
+        return _FakeResponse(self._response)
+
+
+def test_huggingface_service_parses_structured_task_spec() -> None:
+    fake_response = """
+    {"goal": "Move the crate", "constraints": ["Be careful"],
+     "environment_context": {"env": "demo"}, "success_criteria": ["done"],
+     "required_payload_kg": 3.5, "source_location": "storage_rack",
+     "target_location": "loading_dock", "priority": 2}
+    """
+    client = _FakeClient([fake_response])
+    service = HuggingFaceGemmaService(config=HuggingFaceConfig(), client=client)
+
+    spec = service.analyze_requirement("Move the crate", knowledge_base={"env": "demo"})
+
+    assert spec.goal == "Move the crate"
+    assert spec.constraints == ["Be careful"]
+    assert spec.environment_context["env"] == "demo"
+    assert spec.target_location == "loading_dock"
+    assert spec.priority == 2
+
+
+def test_huggingface_compiler_extracts_tdl_block() -> None:
+    tdl_block = """```tdl\nTDL TASK auto_generated_task {\n  precondition: robot_ready\n  steps:\n    - move_to name='storage_rack' coords=(1.000, 0.000, 0.000) joints={'j1': 1.0} gripper=hold\n  postcondition: task_complete\n}\n```"""
+    client = _FakeClient([tdl_block])
+    compiler = GemmaTDLCompiler(config=HuggingFaceConfig(), client=client)
+    task = TaskSpec(
+        goal="Move the crate",
+        constraints=[],
+        environment_context={},
+        success_criteria=[],
+        required_payload_kg=0.0,
+    )
+    plan = MotionPlan(
+        steps=[
+            MotionStep(
+                waypoint=Waypoint(name="storage_rack", position=(1.0, 0.0, 0.0)),
+                joint_targets={"j1": 1.0},
+                gripper="hold",
+            )
+        ],
+        duration_s=12.3,
+    )
+
+    program = compiler.generate_program(task, plan)
+
+    assert "TDL TASK auto_generated_task" in program.text
+    assert program.metadata["generated_from"] == "GemmaTDLCompiler"
+    assert program.metadata["model"] == HuggingFaceConfig().model
+
+
+def test_huggingface_service_falls_back_to_stop_sequences() -> None:
+    fake_response = """{"goal": "Move the crate"}"""
+    client = _StopFallbackClient(fake_response)
+    service = HuggingFaceGemmaService(config=HuggingFaceConfig(), client=client)
+
+    spec = service.analyze_requirement("Move the crate")
+
+    assert spec.goal == "Move the crate"
+    assert any("stop" in call for call in client.calls)
+    assert any("stop_sequences" in call for call in client.calls)


### PR DESCRIPTION
## Summary
- update the Hugging Face chat wrapper to fall back between stop and stop_sequences keywords for compatibility with different huggingface_hub versions
- add a regression test ensuring the requirement analyzer retries with stop_sequences when stop is rejected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca8bb1038832398a8460c8db5a3d0